### PR TITLE
#4 Issue: Minimal required php version is not set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3.0",
-        "ext-json": "*"
+        "php": ">=5.6",
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^6.3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See issue: https://github.com/tvip/tmsproviderapiphpsdk/issues/4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Declare minimal supported PHP version (>=5.6) in composer.json.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8344295bf49331a5bff7adc750679b6113e39572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->